### PR TITLE
Bump patch version to fix Gemfury conflict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pykss',
-    version='0.6',
+    version='0.6.1',
     description='Python implementation of KSS',
     long_description=open('README.rst').read(),
     author='Kundo',


### PR DESCRIPTION
There seems to be a conflict in the different versions of pykss on our GemFury server.

When installing dependencies in storkundo, we get this warning:

```
Collecting pykss==0.6
  Downloading https://pypi.fury.io/_RRDWoPKWSqFA1x6sez_/kundo-team-account/-/ver_1hv2AL/pykss-0.6.tar.gz (15 kB)
  WARNING: Requested pykss==0.6 from https://pypi.fury.io/_RRDWoPKWSqFA1x6sez_/kundo-team-account/-/ver_1hv2AL/pykss-0.6.tar.gz#md5=4b1bd8601aa71a77d106cd8c810d751e (from -r requirements/dev.
txt (line 735)), but installing version 0.5
```

This is an attempt at fixing the above error by bumping the patch version and hoping that CircleCI manages to upload a new version of the package.

Co-authored-by: Gabriel Östlund <gabriel.ostlund@kundo.se>
Co-authored-by: Maria Hansson <maria.hansson@kundo.se>